### PR TITLE
Add HVAC mode and action sets for climate entities

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -65,6 +65,10 @@ HVAC_MODE_SETS = {
         HVAC_MODE_HEAT: "Manual",
         HVAC_MODE_AUTO: "Auto",
     },
+    "MANUAL/AUTO": {
+        HVAC_MODE_HEAT: "MANUAL",
+        HVAC_MODE_AUTO: "AUTO",
+    },
     "Manual/Program": {
         HVAC_MODE_HEAT: "Manual",
         HVAC_MODE_AUTO: "Program",
@@ -97,6 +101,10 @@ HVAC_ACTION_SETS = {
     "Heat/Warming": {
         CURRENT_HVAC_HEAT: "Heat",
         CURRENT_HVAC_IDLE: "Warming",
+    },
+    "heating/warming": {
+        CURRENT_HVAC_HEAT: "heating",
+        CURRENT_HVAC_IDLE: "warming",
     },
 }
 PRESET_SETS = {


### PR DESCRIPTION
Pulling in similar work from [RutgerKe](https://github.com/RutgerKe)

These are the actions and modes as reported by the Magnum smart wifi
thermostat: https://www.magnumheating.com/product/remote-control/